### PR TITLE
Update ContextFunctions.scala: use 2 spaces for scaladoc list items

### DIFF
--- a/src/main/scala/ContextFunctions.scala
+++ b/src/main/scala/ContextFunctions.scala
@@ -3,8 +3,8 @@ import scala.util.Try
 
 /**
   * Context Functions:
-  * - https://dotty.epfl.ch/docs/reference/contextual/context-functions.html
-  * - https://www.scala-lang.org/blog/2016/12/07/implicit-function-types.html
+  *  - https://dotty.epfl.ch/docs/reference/contextual/context-functions.html
+  *  - https://www.scala-lang.org/blog/2016/12/07/implicit-function-types.html
   */
 object ContextFunctions {
 


### PR DESCRIPTION
add extra space to scala doc list items according to ScalaDoc rules (scala 2 though)

```scala
/**
 * List1:
 * - item1
 * - item2
 *
 * List2:
 *  - item1
 *  - item2
 */
class DocTest {

}
```

![image](https://user-images.githubusercontent.com/3989292/108103230-b2aeb280-709a-11eb-8fbd-d989379471b4.png)

![image](https://user-images.githubusercontent.com/3989292/108103248-b9d5c080-709a-11eb-96ba-692a27502f4d.png)
