### PR TITLE
Main.scala: use proper @main function

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,5 +1,5 @@
-def main(args: Array[String]): Unit =
-
+@main
+def Main(args: String*): Unit =
   runExample("Trait Params")(TraitParams.test())
 
   runExample("Enum Types")(EnumTypes.test())
@@ -23,7 +23,7 @@ def main(args: Array[String]): Unit =
   runExample("Structural Types")(StructuralTypes.test())
 
   runExample("Pattern Matching")(PatternMatching.test())
-end main
+end Main
 
 private def runExample(name: String)(f: => Unit): Unit =
   println(Console.MAGENTA + s"$name example:" + Console.RESET)


### PR DESCRIPTION
according to https://dotty.epfl.ch/docs/reference/changed-features/main-functions.html
1. you should use `@main` annotation to make the function actual "runnable", "main" function
2. parameter type should be `String*` , not `Array[String]` (`Array[String]` leads to a compilation error)

\+ method name was changed to uppercase `Main` because `main` will lead to the compiler warning:
```
The class `main` generated from `@main` will shadow the existing class main in package scala
```

related https://youtrack.jetbrains.com/issue/SCL-18763